### PR TITLE
feat: add automatic refresh token cleanup with scheduled task

### DIFF
--- a/src/main/java/com/example/inventoryManagementRetail/InventoryManagementRetailApplication.java
+++ b/src/main/java/com/example/inventoryManagementRetail/InventoryManagementRetailApplication.java
@@ -2,8 +2,10 @@ package com.example.inventoryManagementRetail;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class InventoryManagementRetailApplication {
     public static void main(String[] args) {
         SpringApplication.run(InventoryManagementRetailApplication.class, args);

--- a/src/main/java/com/example/inventoryManagementRetail/config/SecurityConfig.java
+++ b/src/main/java/com/example/inventoryManagementRetail/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
         this.authenticationProvider = authenticationProvider;
     }
 
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -38,7 +39,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/auth/**",
+                                "/auth/login",
+                                "/auth/register",
+                                "/auth/refresh",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/com/example/inventoryManagementRetail/controller/AuthController.java
+++ b/src/main/java/com/example/inventoryManagementRetail/controller/AuthController.java
@@ -1,16 +1,13 @@
 package com.example.inventoryManagementRetail.controller;
 
+import com.example.inventoryManagementRetail.dto.User.Login.AuthenticationRequestDto;
+import com.example.inventoryManagementRetail.dto.User.Login.AuthenticationResponse;
+import com.example.inventoryManagementRetail.dto.User.Me.MeResponse;
 import com.example.inventoryManagementRetail.dto.User.Register.RegisterRequest;
-import com.example.inventoryManagementRetail.dto.User.Register.RegisterResponse;
-import com.example.inventoryManagementRetail.dto.User.login.AuthenticationRequestDto;
-import com.example.inventoryManagementRetail.dto.User.login.AuthenticationResponse;
 import com.example.inventoryManagementRetail.service.AuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -24,14 +21,26 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<AuthenticationResponse> login(@Valid @RequestBody AuthenticationRequestDto request) {
-        AuthenticationResponse response = authService.login(request);
-        return ResponseEntity.ok(response);
+        return authService.login(request);
     }
 
     @PostMapping("/register")
-    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
-        RegisterResponse response = authService.register(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<AuthenticationResponse> register(@Valid @RequestBody RegisterRequest request) {
+        return authService.register(request);
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<MeResponse> me() {
+        return authService.me();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthenticationResponse> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        return authService.refreshTokenExchange(refreshToken);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<AuthenticationResponse> logout(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        return authService.logout(refreshToken);
+    }
 }

--- a/src/main/java/com/example/inventoryManagementRetail/dto/User/Login/AuthenticationRequestDto.java
+++ b/src/main/java/com/example/inventoryManagementRetail/dto/User/Login/AuthenticationRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.inventoryManagementRetail.dto.User.login;
+package com.example.inventoryManagementRetail.dto.User.Login;
 
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/inventoryManagementRetail/dto/User/Login/AuthenticationResponse.java
+++ b/src/main/java/com/example/inventoryManagementRetail/dto/User/Login/AuthenticationResponse.java
@@ -1,4 +1,4 @@
-package com.example.inventoryManagementRetail.dto.User.login;
+package com.example.inventoryManagementRetail.dto.User.Login;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AuthenticationResponse {
-    private String token;
+    private String message;
 }

--- a/src/main/java/com/example/inventoryManagementRetail/dto/User/Me/MeResponse.java
+++ b/src/main/java/com/example/inventoryManagementRetail/dto/User/Me/MeResponse.java
@@ -1,0 +1,16 @@
+package com.example.inventoryManagementRetail.dto.User.Me;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class MeResponse {
+    private String userName;
+    private List<String> roles;
+    private String message;
+}

--- a/src/main/java/com/example/inventoryManagementRetail/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/inventoryManagementRetail/exception/GlobalExceptionHandler.java
@@ -42,4 +42,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleInsufficientResourcesException(InsufficientResourcesException ex) {
         return ResponseEntity.status(HttpStatus.INSUFFICIENT_STORAGE).body(ex.getMessage());
     }
+
+    @ExceptionHandler(RefreshTokenException.class)
+    public ResponseEntity<String> handleRefreshTokenExpired(RefreshTokenException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
 }

--- a/src/main/java/com/example/inventoryManagementRetail/exception/RefreshTokenException.java
+++ b/src/main/java/com/example/inventoryManagementRetail/exception/RefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.example.inventoryManagementRetail.exception;
+
+public class RefreshTokenException extends RuntimeException {
+    public RefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/inventoryManagementRetail/model/RefreshToken.java
+++ b/src/main/java/com/example/inventoryManagementRetail/model/RefreshToken.java
@@ -1,0 +1,29 @@
+package com.example.inventoryManagementRetail.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String token;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+}

--- a/src/main/java/com/example/inventoryManagementRetail/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/inventoryManagementRetail/repository/RefreshTokenRepository.java
@@ -1,0 +1,27 @@
+package com.example.inventoryManagementRetail.repository;
+
+import com.example.inventoryManagementRetail.model.RefreshToken;
+import com.example.inventoryManagementRetail.model.User;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<com.example.inventoryManagementRetail.model.RefreshToken> findByToken(String Token);
+
+    @Modifying
+    @Transactional
+    @Query("delete from RefreshToken r where r.user = :user")
+    void deleteByUser(User user);
+
+    @Modifying
+    @Transactional
+    @Query("delete from RefreshToken r where r.expiryDate < :cutoffTime")
+    Optional<Integer> deleteExpiredTokensOlderThan(@Param("cutoffTime") Instant cutoffTime);
+}

--- a/src/main/java/com/example/inventoryManagementRetail/security/Jwt/RefreshTokenCleanupTask.java
+++ b/src/main/java/com/example/inventoryManagementRetail/security/Jwt/RefreshTokenCleanupTask.java
@@ -1,0 +1,27 @@
+package com.example.inventoryManagementRetail.security.Jwt;
+
+import com.example.inventoryManagementRetail.repository.RefreshTokenRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@Component
+public class RefreshTokenCleanupTask {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshTokenCleanupTask(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Scheduled(fixedDelay = 86400000)
+    public void deleteExpiredTokens() {
+        Instant cutoffTime = Instant.now().minus(Duration.ofHours(24));
+        Integer deleteCount = refreshTokenRepository.deleteExpiredTokensOlderThan(cutoffTime).orElseThrow(() -> new RuntimeException("Failed to delete expired tokens"));
+        log.info("Delete {} expired tokens", deleteCount);
+    }
+}

--- a/src/main/java/com/example/inventoryManagementRetail/service/AuthService.java
+++ b/src/main/java/com/example/inventoryManagementRetail/service/AuthService.java
@@ -1,19 +1,34 @@
 package com.example.inventoryManagementRetail.service;
 
+import com.example.inventoryManagementRetail.dto.User.Login.AuthenticationRequestDto;
+import com.example.inventoryManagementRetail.dto.User.Login.AuthenticationResponse;
+import com.example.inventoryManagementRetail.dto.User.Me.MeResponse;
 import com.example.inventoryManagementRetail.dto.User.Register.RegisterRequest;
-import com.example.inventoryManagementRetail.dto.User.Register.RegisterResponse;
-import com.example.inventoryManagementRetail.dto.User.login.AuthenticationRequestDto;
-import com.example.inventoryManagementRetail.dto.User.login.AuthenticationResponse;
+import com.example.inventoryManagementRetail.exception.DuplicateResourceException;
+import com.example.inventoryManagementRetail.exception.ResourceNotFoundException;
+import com.example.inventoryManagementRetail.model.RefreshToken;
 import com.example.inventoryManagementRetail.model.User;
 import com.example.inventoryManagementRetail.repository.UserRepository;
 import com.example.inventoryManagementRetail.security.Jwt.JwtUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -23,56 +38,160 @@ public class AuthService {
     private final UserRepository userRepository;
     private final AuthenticationManager authenticationManager;
     private final UserDetailsServiceImpl userDetailsService;
+    private final RefreshTokenService refreshTokenService;
     private final JwtUtils jwtUtils;
 
-    public AuthService(PasswordEncoder passwordEncoder, UserRepository userRepository, AuthenticationManager authenticationManager, UserDetailsServiceImpl userDetailsService, JwtUtils jwtUtils) {
+    public AuthService(PasswordEncoder passwordEncoder, UserRepository userRepository, AuthenticationManager authenticationManager, UserDetailsServiceImpl userDetailsService, RefreshTokenService refreshTokenService, JwtUtils jwtUtils) {
         this.passwordEncoder = passwordEncoder;
         this.userRepository = userRepository;
         this.authenticationManager = authenticationManager;
         this.userDetailsService = userDetailsService;
+        this.refreshTokenService = refreshTokenService;
         this.jwtUtils = jwtUtils;
     }
 
-    public AuthenticationResponse login(AuthenticationRequestDto request) {
-        try {
-            authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(request.getUserName(), request.getPassword())
-            );
-            UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUserName());
-            String jwt = jwtUtils.generateToken(userDetails);
-            return new AuthenticationResponse(jwt);
-        } catch (AuthenticationException e) {
-            throw new RuntimeException("Invalid credentials");
-        }
+    public ResponseEntity<AuthenticationResponse> login(AuthenticationRequestDto request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUserName(), request.getPassword())
+        );
+        UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUserName());
+        String jwt = jwtUtils.generateToken(userDetails);
+
+        ResponseCookie cookie = ResponseCookie.from("token", jwt)
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(900)
+                .build();
+
+        User user = userRepository.findByUserName(request.getUserName()).orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        refreshTokenService.deleteByUser(user);
+        RefreshToken refreshToken = refreshTokenService.createRefreshToken(user);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken.getToken())
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.between(Instant.now(), refreshToken.getExpiryDate()).getSeconds())
+                .build();
+
+        return ResponseEntity
+                .ok()
+                .headers(headers -> {
+                    headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+                    headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+                })
+                .body(new AuthenticationResponse("Login successfully"));
     }
 
-    public RegisterResponse register(RegisterRequest request) {
+    public ResponseEntity<AuthenticationResponse> refreshTokenExchange(String refreshTokenValue) {
+        if (refreshTokenValue == null || refreshTokenValue.isBlank()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new AuthenticationResponse("refresh token missing"));
+        }
+        RefreshToken refreshToken = refreshTokenService.findByToken(refreshTokenValue).orElseThrow(() -> new ResourceNotFoundException("Refresh token not found"));
+        refreshTokenService.verifyExpiration(refreshToken);
+        User user = refreshToken.getUser();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(user.getUserName());
+        String newJwt = jwtUtils.generateToken(userDetails);
+
+        refreshTokenService.deleteByUser(user);
+        RefreshToken newRefresh = refreshTokenService.createRefreshToken(user);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", newRefresh.getToken())
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.between(Instant.now(), newRefresh.getExpiryDate()).getSeconds())
+                .build();
+
+        ResponseCookie newAccessCookie = ResponseCookie.from("token", newJwt)
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(900)
+                .build();
+
+        return ResponseEntity.ok().headers(headers -> {
+                    headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+                    headers.add(HttpHeaders.SET_COOKIE, newAccessCookie.toString());
+                })
+                .body(new AuthenticationResponse("Refresh token successfully"));
+    }
+
+    public ResponseEntity<AuthenticationResponse> register(RegisterRequest request) {
+        if (userRepository.findByUserName(request.getUserName()).isPresent()) {
+            throw new DuplicateResourceException("User already exists");
+        }
+        String passwordEncoded = passwordEncoder.encode(request.getPassword());
+        User user = User.builder()
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail())
+                .userName(request.getUserName())
+                .password(passwordEncoded)
+                .roles(request.getRoles())
+                .build();
+        user = userRepository.save(user);
+        log.info("User registered successfully: {}", user.getUserName());
+        return login(new AuthenticationRequestDto(request.getUserName(), request.getPassword()));
+    }
+
+    public ResponseEntity<AuthenticationResponse> logout(String refreshToken) {
         try {
-            if (userRepository.findByUserName(request.getUserName()).isPresent()) {
-                throw new IllegalArgumentException("User Already Exists");
+            if (refreshToken == null || refreshToken.isBlank()) {
+                log.warn("Logout attempted without refresh token");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(new AuthenticationResponse("refresh token missing"));
             }
-            String passwordEncoded = passwordEncoder.encode(request.getPassword());
-            User user = User.builder()
-                    .firstName(request.getFirstName())
-                    .lastName(request.getLastName())
-                    .email(request.getEmail())
-                    .userName(request.getUserName())
-                    .password(passwordEncoded)
-                    .roles(request.getRoles())
+            refreshTokenService
+                    .findByToken(refreshToken)
+                    .ifPresent(token -> {
+                        refreshTokenService.deleteByUser(token.getUser());
+                        log.info("Refresh token deleted for user {}", token.getUser().getUserName());
+                    });
+            ResponseCookie clearTokenCookie = ResponseCookie.from("token", "")
+                    .httpOnly(true)
+                    .path("/")
+                    .maxAge(0)
                     .build();
-            user = userRepository.save(user);
-            log.info("User registered successfully: {}", user.getUserName());
-            return RegisterResponse.builder()
-                    .firstName(user.getFirstName())
-                    .lastName(user.getLastName())
-                    .email(user.getEmail())
-                    .userName(user.getUserName())
-                    .roles(user.getRoles())
+            ResponseCookie clearRefreshCookie = ResponseCookie.from("refreshToken", "")
+                    .httpOnly(true)
+                    .secure(false)
+                    .sameSite("Lax")
+                    .path("/")
+                    .maxAge(0)
                     .build();
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, clearTokenCookie.toString())
+                    .header(HttpHeaders.SET_COOKIE, clearRefreshCookie.toString())
+                    .body(new AuthenticationResponse("Logged out successfully"));
         } catch (Exception e) {
-            log.error("Error while registering user: {}", e.getMessage());
-            throw new RuntimeException("Error while registering user: " + e.getMessage());
+            log.warn("Error while logging out: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AuthenticationResponse("Error while logging out"));
         }
     }
 
+    public ResponseEntity<MeResponse> me() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new MeResponse(null, Collections.emptyList(), "Not authenticated"));
+        }
+
+        Object principal = authentication.getPrincipal();
+        String username;
+        List<String> roles;
+        if (principal instanceof UserDetails user) {
+            username = user.getUsername();
+            roles = user.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
+        } else {
+            username = principal != null ? principal.toString() : "unknown";
+            roles = List.of();
+        }
+
+        return ResponseEntity.ok(new MeResponse(username, roles, "Authenticated"));
+    }
 }

--- a/src/main/java/com/example/inventoryManagementRetail/service/RefreshTokenService.java
+++ b/src/main/java/com/example/inventoryManagementRetail/service/RefreshTokenService.java
@@ -1,0 +1,51 @@
+package com.example.inventoryManagementRetail.service;
+
+import com.example.inventoryManagementRetail.exception.RefreshTokenException;
+import com.example.inventoryManagementRetail.model.RefreshToken;
+import com.example.inventoryManagementRetail.model.User;
+import com.example.inventoryManagementRetail.repository.RefreshTokenRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    @Value("${app.jwt.refreshTokenExpirationSec}")
+    private Long refreshTokenDurationSec;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    public RefreshToken createRefreshToken(User user) {
+        RefreshToken RToken = new RefreshToken();
+        RToken.setUser(user);
+        RToken.setToken(UUID.randomUUID().toString());
+        RToken.setExpiryDate(Instant.now().plusSeconds(refreshTokenDurationSec));
+        return refreshTokenRepository.save(RToken);
+    }
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public void verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().isBefore(Instant.now())) {
+            log.error("Refresh Token is Expired");
+            refreshTokenRepository.delete(token);
+            throw new RefreshTokenException("Refresh Token is Expired");
+        }
+    }
+
+    public void deleteByUser(User user) {
+        refreshTokenRepository.deleteByUser(user);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,48 @@
+############################
+# APPLICATION CONFIGURATION
+############################
+# Application name (used for logs, Spring Actuator, etc.)
 spring.application.name=inventoryManagementRetail
 
+# Port where the embedded server (Tomcat) runs
 server.port=8081
+
+############################
+# DATABASE CONFIGURATION
+############################
+# PostgreSQL connection URL
 spring.datasource.url=jdbc:postgresql://localhost:5432/inventoryManagementRetail
+
+# Database credentials (using environment variables for security)
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+
+# PostgreSQL JDBC driver
 spring.datasource.driver-class-name=org.postgresql.Driver
-jwt.secret = ${JWT_SECRET}
+
+############################
+# JPA / HIBERNATE CONFIGURATION
+############################
+# Schema generation strategy:
+# update = updates tables without dropping data (recommended for development)
+spring.jpa.hibernate.ddl-auto=update
+
+# Show SQL queries in the console
+spring.jpa.show-sql=true
+
+############################
+# SECURITY CONFIGURATION - JWT
+############################
+# Secret key used to sign JWT tokens
+jwt.secret=${JWT_SECRET}
+
+# JWT access token expiration time (in milliseconds)
+# 3600000 ms = 1 hour
 expiration.time=3600000
+
+# Refresh token expiration time (in seconds)
+# 3600 s = 1 hour
+app.jwt.refreshTokenExpirationSec=604800
+
+# ATTENTION: Change this to true in production!!
+app.jwt.cookie.secure=false


### PR DESCRIPTION
Implement automated database maintenance for refresh tokens:
- Add deleteExpiredTokensOlderThan() method to RefreshTokenRepository to safely remove tokens older than 24 hours, preventing database accumulation of expired tokens
- Create RefreshTokenCleanupTask component that automatically executes every 24 hours to clean up stale refresh tokens
- Enable @EnableScheduling in main application class to activate scheduled task execution
- Use 24-hour safety buffer to only delete tokens expired longer than one day, avoiding accidental deletion of recently expired tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token refresh capability for improved session management
  * User profile endpoint to view account details and assigned roles
  * Logout functionality to securely end sessions and clear tokens
  * Enhanced authentication using cookie-based token storage

* **Improvements**
  * Improved handling of expired JWT tokens with proper error responses
  * Automatic cleanup of expired refresh tokens

* **Chores**
  * Enhanced security configuration for better endpoint protection
  * Enabled application-level scheduling for maintenance tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->